### PR TITLE
bug/discard while taking picture

### DIFF
--- a/documentscanner/src/main/java/nz/mega/documentscanner/DocumentScannerActivity.kt
+++ b/documentscanner/src/main/java/nz/mega/documentscanner/DocumentScannerActivity.kt
@@ -96,32 +96,39 @@ class DocumentScannerActivity : AppCompatActivity() {
         }
     }
 
-    private fun onResultDocument(documentUri: Uri) {
-        if (callingActivity != null) {
-            val resultIntent = Intent().apply {
-                putExtra(EXTRA_PICKED_SAVE_DESTINATION, viewModel.getSaveDestination())
-                setDataAndType(documentUri, contentResolver.getType(documentUri))
+    private fun onResultDocument(documentUri: Uri?) {
+        when {
+            documentUri == null -> {
+                setResult(Activity.RESULT_CANCELED)
             }
-            setResult(Activity.RESULT_OK, resultIntent)
-            finish()
-        } else {
-            val providerAuthority = FileUtils.getProviderAuthority(this)
-            val fileUri = FileProvider.getUriForFile(this, providerAuthority, documentUri.toFile())
-            val fileMimeType = contentResolver.getType(fileUri)
-            val fileTitle = viewModel.getDocumentTitle().value
-
-            val shareIntent = ShareCompat.IntentBuilder.from(this)
-                .setType(fileMimeType)
-                .setChooserTitle(fileTitle)
-                .setStream(fileUri)
-                .createChooserIntent()
-                .apply {
-                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            callingActivity != null -> {
+                val resultIntent = Intent().apply {
                     putExtra(EXTRA_PICKED_SAVE_DESTINATION, viewModel.getSaveDestination())
+                    setDataAndType(documentUri, contentResolver.getType(documentUri))
                 }
+                setResult(Activity.RESULT_OK, resultIntent)
+            }
+            else -> {
+                val providerAuthority = FileUtils.getProviderAuthority(this)
+                val fileUri = FileProvider.getUriForFile(this, providerAuthority, documentUri.toFile())
+                val fileMimeType = contentResolver.getType(fileUri)
+                val fileTitle = viewModel.getDocumentTitle().value
 
-            startActivity(shareIntent)
+                val shareIntent = ShareCompat.IntentBuilder.from(this)
+                    .setType(fileMimeType)
+                    .setChooserTitle(fileTitle)
+                    .setStream(fileUri)
+                    .createChooserIntent()
+                    .apply {
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        putExtra(EXTRA_PICKED_SAVE_DESTINATION, viewModel.getSaveDestination())
+                    }
+
+                startActivity(shareIntent)
+            }
         }
+
+        finish()
     }
 
     private fun findNavController(): NavController =

--- a/documentscanner/src/main/java/nz/mega/documentscanner/DocumentScannerViewModel.kt
+++ b/documentscanner/src/main/java/nz/mega/documentscanner/DocumentScannerViewModel.kt
@@ -40,9 +40,9 @@ class DocumentScannerViewModel : ViewModel() {
     private val document: MutableLiveData<Document> = MutableLiveData(Document())
     private val saveDestinations: MutableLiveData<Array<String>> = MutableLiveData()
     private val currentPagePosition: MutableLiveData<Int> = MutableLiveData(0)
-    private val resultDocument: MutableLiveData<Uri> = MutableLiveData()
+    private val resultDocument: MutableLiveData<Uri?> = MutableLiveData()
 
-    fun getResultDocument(): LiveData<Uri> =
+    fun getResultDocument(): LiveData<Uri?> =
         resultDocument
 
     fun getDocumentTitle(): LiveData<String> =
@@ -244,6 +244,14 @@ class DocumentScannerViewModel : ViewModel() {
             document.value?.deletePages()
             document.notifyObserver()
         }
+    }
+
+    /**
+     * Reset current document and close the scanner
+     */
+    fun discardScan() {
+        resetDocument()
+        resultDocument.value = null
     }
 
     /**

--- a/documentscanner/src/main/java/nz/mega/documentscanner/camera/CameraFragment.kt
+++ b/documentscanner/src/main/java/nz/mega/documentscanner/camera/CameraFragment.kt
@@ -79,7 +79,7 @@ class CameraFragment : Fragment() {
     }
 
     private fun setupView() {
-        binding.btnBack.setOnClickListener { viewModel.discardScan() }
+        binding.btnBack.setOnClickListener { showDiscardDialog() }
 
         if (allPermissionsGranted()) {
             binding.cameraView.post { setUpCamera() }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
> Press back at scanning page, will exit the whole scanning process(already taken pictures will lost).
Please refer to the video: https://mega.nz/file/KKRSxYZB#H_2q-mZl4LcjMnJ1kY2R3qUSK3E1e-VJmzTKotfTOao

Fix reported issue by checking current pages before closing camera view.

## Any relevant logs, error output, etc?
...

## Any other comments?
https://github.com/meganz/android2/pull/1454#pullrequestreview-576996706

## Where has this been tested?

- **Devices/Simulators:** 
Google Pixel 4

- **OS Version:** 
Android 11